### PR TITLE
Fixes broken UI

### DIFF
--- a/src/lib/faqItem.svelte
+++ b/src/lib/faqItem.svelte
@@ -11,12 +11,12 @@
 		<!-- Expand/collapse question button -->
 		<button
 			type="button"
-			class="text-left w-full flex justify-between items-start text-v-black"
+			class="my-12 text-left w-full flex justify-between items-start text-v-black"
 			aria-controls="faq-0"
 			aria-expanded="false"
 			on:click={() => (show = !show)}
 		>
-			<h4 class="mb-0">{question}</h4>
+			<h4 style="margin:0;" class="mb-0">{question}</h4>
 			<span class="ml-6 h-7 flex items-center">
 				<ChevronRight class="{show ? 'rotate-90' : 'rotate-0'} h-6 w-6 transform" />
 			</span>

--- a/src/routes/projects/project.svelte
+++ b/src/routes/projects/project.svelte
@@ -49,7 +49,7 @@
 			<h3 class="mb-0 group-hover:text-v-gray">{project.name}</h3>
 			<p class="mb-2 group-hover:text-v-gray">{repo.description}</p>
 		</a>
-		<div class="-my-2 flex flex-wrap gap-x-4 mb-6">
+		<div class="my-2 flex flex-wrap gap-x-4 mb-6">
 			{#each repo.topics as topic}
 				<span class="inline-flex items-center my-2 px-3 py-0.5 bg-v-gray">
 					<p class="m-0 text-v-white">{topic}</p>

--- a/src/routes/work/continuous-delivery-workshop/_stages.svelte
+++ b/src/routes/work/continuous-delivery-workshop/_stages.svelte
@@ -88,10 +88,10 @@
 <div class="my-8">
 	<dl class="flex flex-col">
 		{#each stageDescriptions[selected] as item}
-			<div class="flex flex-col gap-y-2">
+			<div class="my-4 flex flex-col gap-y-2 my-4">
 				<dt class="flex items-center gap-x-4">
 					<img class="h-4 w-4 object-contain" src="/logo-element.png" alt="logo-ement" />
-					<h4 class="mb-0 group-hover:text-v-lilac">{item.title}</h4>
+					<h4 style="margin:0;" class="mb-0 group-hover:text-v-lilac">{item.title}</h4>
 				</dt>
 				<dd>
 					<p class="pl-8">

--- a/src/routes/work/continuous-delivery-workshop/_waste.svelte
+++ b/src/routes/work/continuous-delivery-workshop/_waste.svelte
@@ -64,10 +64,10 @@
 	{#each wastes as waste, index}
 		<div class="flex flex-col gap-y-2">
 			<button on:click={() => (showWastes[index] = !showWastes[index])}>
-				<dt class="flex items-center gap-x-4">
+				<dt class="flex items-center gap-x-4 my-4">
 					<img class="object-contain w-12 h-12" src={waste.img} alt="waste-type" />
 					<div class="group flex items-center gap-x-4">
-						<h4 class="mb-0 group-hover:text-v-lilac">{waste.name}</h4>
+						<h4 style="margin:0;" class="mb-0 group-hover:text-v-lilac">{waste.name}</h4>
 						<ChevronRight
 							class="h-6 w-6 group-hover:text-v-lilac {showWastes[index]
 								? 'rotate-90'


### PR DESCRIPTION
### Updated !

Fixes #85 by adding `style="margin:0"` to misaligned headings.

* Aligns waste properties & icon under **Types of waste** on [cd workshop](https://verifa.io/work/continuous-delivery-workshop/) page.

| Before | After |
| :---------------------: | :---------------------: |
| ![waste-before](https://github.com/verifa/website/assets/129554482/5f3342a5-3754-4b0c-b88c-b3658546fefe) |![waste-after](https://github.com/verifa/website/assets/129554482/6e8e00a9-ea06-4bc9-9ebf-cb1c05d0e8a9)|

* Aligns workshop stages pointers on [cd workshop](https://verifa.io/work/continuous-delivery-workshop/) page.

| Before | After |
| :---------------------: | :---------------------: |
|![before-stage](https://github.com/verifa/website/assets/129554482/d5b3663e-255f-4c8c-91c1-c926b9c1ca38) |![after-stage](https://github.com/verifa/website/assets/129554482/1e8c36c1-a4fa-496e-a91b-634a56c2151f)|

* Aligns continuous delivery principle label and > icon on [cd workshop](https://verifa.io/work/continuous-delivery-workshop/) page.

| Before | After |
| :---------------------: | :---------------------: |
|![cd-before](https://github.com/verifa/website/assets/129554482/0776a63c-df0c-4925-b690-8adba3ec5549) |![cd-after](https://github.com/verifa/website/assets/129554482/c75ca3c1-bda7-4ce1-9f34-cdc459f45cff)|

* Fixes gap between project description and topics on [projects](https://verifa.io/projects/) page.

| Before | After |
| :---------------------: | :---------------------: |
|![projects-before](https://github.com/verifa/website/assets/129554482/204f197d-0245-4234-b390-bb2ce7aba859)|![projects-after](https://github.com/verifa/website/assets/129554482/8d1b4d67-1227-44ba-8663-b0142f1d9326)|
