### PR TITLE
Swap utterances for giscus

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains Verifa's website live at <https://verifa.io>
 ### Other notable mentions
 
 1. [mdsvex](https://mdsvex.pngwn.io/) - for converting Markdown into pages
-2. [utterances](https://utteranc.es/) - adding comments to our blog using GitHub issues
+2. [giscus](https://giscus.app/) - adding comments to our blog using GitHub discussions
 
 ## Design
 

--- a/src/lib/posts/layout.svelte
+++ b/src/lib/posts/layout.svelte
@@ -75,16 +75,7 @@
 	<hr />
 	<section>
 		<h2>Comments</h2>
-		<script
-			src="https://utteranc.es/client.js"
-			data-repo="verifa/website"
-			data-issue-term="pathname"
-			data-label="blog"
-			data-theme="boxy-light"
-			crossorigin="anonymous"
-			async
-		>
-		</script>
+		<script src="https://giscus.app/client.js" data-repo="verifa/website" data-repo-id="R_kgDOGo3alQ" data-category="Blog" data-category-id="DIC_kwDOGo3alc4CcKOD" data-mapping="pathname" data-strict="0" data-reactions-enabled="1" data-emit-metadata="0" data-input-position="bottom" data-theme="preferred_color_scheme" data-lang="en" crossorigin="anonymous" async></script>
 	</section>
 	{#if post.type != PostType.Case}
 		<section>


### PR DESCRIPTION
This PR swaps out the comments section script for giscus. It's a drop-in replacement, with the exception of giscus using Discussions instead of Issues. Fortunately Issues can be converted to Discussions with a few clicks.

At the same time as merging this PR, the existing utterances should be converted to Discussions in the "Open Ended Discussions" category.
See: https://shipit.dev/posts/from-utterances-to-giscus.html

Thank you to @jlarfors for doing the actual leg work of implementing the giscus script line.